### PR TITLE
15 fix ping pong example work on non distillation

### DIFF
--- a/cpp/desktop-ping-pong/CMakeLists.txt
+++ b/cpp/desktop-ping-pong/CMakeLists.txt
@@ -24,17 +24,18 @@ project(ping-pong-example VERSION 1.0 LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# by default distillation mode is off, turn it on for this example
+# By default, distillation mode is off; turn it on for this example
 if (NOT DEFINED AE_DISTILLATION)
   set(AE_DISTILLATION On)
 endif()
 
 # add user provided config wich will be included as regular .h file
+# Add a user-provided config file, which will be included as a regular .h file
 set(USER_CONFIG user_config.h)
-# ${USER_CONFIG} must be an absolute path or path to something listed in include directories
+# ${USER_CONFIG} must be an absolute path or a path to something listed in include directories
 include_directories(${CMAKE_CURRENT_LIST_DIR})
 
-# add lib aether dependency
+# Add the Aether library dependency
 add_subdirectory(aether-client-cpp/aether aether)
 
 add_executable(${PROJECT_NAME})

--- a/cpp/desktop-ping-pong/README.md
+++ b/cpp/desktop-ping-pong/README.md
@@ -1,10 +1,10 @@
-# Ping Pong for desktop
+# Ping Pong for Desktop
 
-This is a simple ping pong example with aether client library. It registers two clients *Alice* and *Bob*. *Alice* sends "ping", *Bob* responds "pong".
-The simplest example, but it covers a lot of things lib aether has: aether_app, object, actions, events, streams.
+This is a simple ping pong example using the *aether* client library. It registers two clients, *Alice* and *Bob*. *Alice* sends "ping", and *Bob* responds with "pong".
+This is the simplest example, but it covers many features of the *aether* library: `aether_app`, objects, actions, events, and streams.
 
 ## Build
-Simply use the script provided for different OSes:
+Simply use the provided scripts for different operating systems:
 ```sh
 build_and_run.sh
 ```
@@ -12,10 +12,10 @@ build_and_run.sh
 build_and_run.bat
 ```
 
-## Deep dive
-### The recipe to build
-We are using **CMake** for now. Though some considered it industry standard other build systems also would be supported in the future.
-Lib `aether` requires at least *c++17*, so require it on your project and look at the nex code snippet.
+## Deep Dive
+### The Recipe to Build
+We are using **CMake** for now. Although some consider it an industry standard, other build systems will also be supported in the future.
+The *aether* library requires at least *C++17*, so ensure your project requires it and refer to the following code snippet.
 
 ```cmake
 # By default, distillation mode is off; turn it on for this example
@@ -23,7 +23,6 @@ if (NOT DEFINED AE_DISTILLATION)
   set(AE_DISTILLATION On)
 endif()
 
-# add user provided config wich will be included as regular .h file
 # Add a user-provided config file, which will be included as a regular .h file
 set(USER_CONFIG user_config.h)
 # ${USER_CONFIG} must be an absolute path or a path to something listed in include directories
@@ -33,24 +32,25 @@ include_directories(${CMAKE_CURRENT_LIST_DIR})
 add_subdirectory(aether-client-cpp/aether aether)
 ```
 
-There are two modes `aether` works with: [distillation mode](https://aethernet.io/documentation#c++2) and production mode.
-By default `aether` builds in production mode, but for example only we set `AE_DISTILLATION` option to `On` in cmake script directly.
-In distillation mode `aether` configures all its inner objects in a default states and saves them to the file system.
-Look at the `build/state` directory.
-In production mode `aether` only loads objects with saved states from `./state`.
-It allows not only save time and code to configure big objects, but, for more important, use saved state between application runs.
+There are two modes in which *aether* operates: [distillation mode](https://aethernet.io/documentation#c++2) and production mode.
+By default, *aether* builds in production mode, but for this example, we set the `AE_DISTILLATION` option to `On` directly in the CMake script.
+In distillation mode, *aether* configures all its inner objects to default states and saves them to the file system.
+Check the `build/state` directory.
+In production mode, *aether* only loads objects with saved states from `./state`.
+This not only saves time and code required to configure large objects but, more importantly, allows the use of saved states between application runs.
 
-To configure `aether` library we use configuration header file. All configuration options with its default values listed in `aether/config.h`.
-But user able provide his own through `USER_CONFIG` option.
-It must be absolute path or path relative to something listed in include directories.
+To configure the *aether* library, we use a configuration header file. All configuration options with their default values are listed in `aether/config.h`.
+However, users can provide their own configuration through the `USER_CONFIG` option.
+This must be an absolute path or a path relative to something listed in the include directories (compilers `-I` option).
 
-### Where it all begins
+### Where It All Begins
 ```cpp
 int main() {
   auto aether_app = ae::AetherApp::Construct(ae::AetherAppConstructor{});
 
   std::unique_ptr<Alice> alice;
   std::unique_ptr<Bob> bob;
+  TimeSynchronizer time_synchronizer;
 
   auto client_register_action = ClientRegister{*aether_app};
 
@@ -59,8 +59,8 @@ int main() {
       client_register_action.SubscribeOnResult([&](auto const& action) {
         auto [client_alice, client_bob] = action.get_clients();
         alice = ae::make_unique<Alice>(*aether_app, std::move(client_alice),
-                                       client_bob->uid());
-        bob = ae::make_unique<Bob>(*aether_app, std::move(client_bob));
+                                       time_synchronizer, client_bob->uid());
+        bob = ae::make_unique<Bob>(*aether_app, client_bob, time_synchronizer);
         // Save the current aether state
         aether_app->domain().SaveRoot(aether_app->aether());
       });
@@ -79,31 +79,31 @@ int main() {
 
 Let's go through this!
 
-First create `aether_app` - it's a single object in the aether lib to rule them all. It creates, initializes and provides access to the root [`aether`](https://aethernet.io/documentation#c++2) object,
-and has a helper functions: `Update` and `WaitUntil` to easily integrate it into your update/event loop.
+First, create `aether_app` — it's the single object in the *aether* library that rules them all. It creates, initializes, and provides access to the root `aether` object.
+It also includes helper functions like `Update` and `WaitUntil` to easily integrate it into your update/event loop.
 
-Define our main characters *Alice* and *Bob*.
+Define our main characters, *Alice* and *Bob*.
 
-Create an action to register clients in Aethernet - `client_register_action`.
-[Action](https://aethernet.io/technology#action2) in aether is a concept to perform asynchronous operations.
-Each action is inherited from `ae::Action<T>` and registered in [ActionProcessor](https://aethernet.io/technology#action2) infrastructure.
-It has an `Update` method invoked every loop, where we can manage a state machine or check status of multithreaded tasks.
-To inform about it's state three [events](https://aethernet.io/documentation#c++2) exists: `Result`, `Error`, `Stop` - names speaks for itself.
+Create an action to register clients in Aethernet — `client_register_action`.
+An [action](https://aethernet.io/technology#action2) in *aether* is a concept for performing asynchronous operations.
+Each action inherits from `ae::Action<T>` and is registered in the [ActionProcessor](https://aethernet.io/technology#action2) infrastructure.
+It has an `Update` method invoked every loop, where we can manage a state machine or check the status of multithreaded tasks.
+To inform about its state, three [events](https://aethernet.io/documentation#c++2) exist: `Result`, `Error`, and `Stop` — the names speak for themselves.
 
-We subscribe to `Result` event and obtain clients for *Alice* and *Bob* from action to init our characters and also save current `aether` state.
-On `Error` we close application with exit code 1 as soon as possible.
+We subscribe to the `Result` event and obtain clients for *Alice* and *Bob* from the action to initialize our characters and also save the current `aether` state.
+On `Error`, we close the application with exit code 1 as soon as possible.
 
-For this example clients for `Alice` and `Bob` registered every time application runs in distillation mode.
-But in production mode clients from the saved state used.
-Reconfigure cmake with `AE_DISTILLATION=Off` (just make in your build dir `cmake -DAE_DISTILLATION=Off .`) and rebuild it.
-Next run will be a little faster without registration.
+For this example, clients for `Alice` and `Bob` are registered every time the application runs in distillation mode.
+However, in production mode, clients from the saved state are used.
+Reconfigure CMake with `AE_DISTILLATION=Off` (just run `cmake -DAE_DISTILLATION=Off .` in your build directory) and rebuild it.
+The next run will be slightly faster without registration.
 
-[Event subscription](https://aethernet.io/documentation#c++2) is a RAII object holds subscription to events and unsubscribes on destruction.
+[Event subscription](https://aethernet.io/documentation#c++2) is a RAII object that holds a subscription to events and unsubscribes upon destruction.
 
 ### Alice
 ```cpp
 Alice::Alice(ae::AetherApp& aether_app, ae::Client::ptr client_alice,
-             ae::Uid bobs_uid)
+             TimeSynchronizer& time_synchronizer, ae::Uid bobs_uid)
     : aether_{aether_app.aether()},
       client_alice_{std::move(client_alice)},
       p2pstream_{ae::ActionContext{*aether_->action_processor},
@@ -112,25 +112,30 @@ Alice::Alice(ae::AetherApp& aether_app, ae::Client::ptr client_alice,
                      ae::ActionContext{*aether_->action_processor},
                      client_alice_, bobs_uid, ae::StreamId{0})},
       interval_sender_{ae::ActionContext{*aether_->action_processor},
-                       p2pstream_, std::chrono::milliseconds{5000}},
+                       time_synchronizer, p2pstream_,
+                       std::chrono::milliseconds{5000}},
       interval_sender_subscription_{interval_sender_.SubscribeOnError(
           [&](auto const&) { aether_app.Exit(1); })} {}
 ```
-*Alice* saves pointer to `aether` object, stores `client_alice`, and creates entities there all busyness magics happens.
-She knows *Bob*'s [`uid`](https://aethernet.io/technology#registering-new-client0) and do not mind chatting with him.
 
-Create `p2pstream_`. It's a [`P2pSafeStream`](https://aethernet.io/documentation#c++2), there *Safe* means it guarantees or makes all possible to deliver *Alice's* message to *Bob*.
-Think about [streams](https://aethernet.io/documentation#c++2) like a tunnel through internet and Aethernet servers to another client.
-It's full duplex, so you can scream yor messages to the tunnel and hear the answers simultaneously.
+*Alice* saves a pointer to the `aether` object, stores `client_alice`, and creates entities where all the business magic happens.
+She knows *Bob*'s [`uid`](https://aethernet.io/technology#registering-new-client0) and doesn't mind chatting with him.
 
-*Alice* uses `IntervalSender` - another action, to send her "pings" periodically.
+Create `p2pstream_`. It's a [`P2pSafeStream`](https://aethernet.io/documentation#c++2),
+where *Safe* means it guarantees or makes every effort to deliver *Alice's* message to *Bob*.
+Think of [streams](https://aethernet.io/documentation#c++2) as tunnels through the internet and Aethernet servers to another client.
+They are full-duplex, so you can send messages through the tunnel and receive responses simultaneously.
+
+*Alice* uses `IntervalSender` — another action — to send her "pings" periodically.
 
 ```cpp
 Alice::IntervalSender::IntervalSender(ae::ActionContext action_context,
+                                      TimeSynchronizer& time_synchronizer,
                                       ae::ByteStream& stream,
                                       ae::Duration interval)
     : ae::Action<IntervalSender>{action_context},
       stream_{stream},
+      time_synchronizer_{&time_synchronizer},
       interval_{interval},
       response_subscription_{stream.in().out_data_event().Subscribe(
           *this, ae::MethodPtr<&IntervalSender::ResponseReceived>{})} {}
@@ -138,6 +143,9 @@ Alice::IntervalSender::IntervalSender(ae::ActionContext action_context,
 ae::TimePoint Alice::IntervalSender::Update(ae::TimePoint current_time) {
   if (sent_time_ + interval_ <= current_time) {
     constexpr std::string_view ping_message = "ping";
+
+    time_synchronizer_->SetPingSentTime(current_time);
+
     std::cout << "send \"ping\"" << '\n';
     auto send_action = stream_.in().Write(
         {std::begin(ping_message), std::end(ping_message)}, current_time);
@@ -154,13 +162,16 @@ ae::TimePoint Alice::IntervalSender::Update(ae::TimePoint current_time) {
   return sent_time_ + interval_;
 }
 ```
-`IntervalSender` waits `interval_` time from last `sent_time_` and send new "ping" then. It also subscribed to response messages.
+
+`IntervalSender` waits for `interval_` time from the last `sent_time_` and sends a new "ping" then. It is also subscribed to response messages.
 
 ### Bob
 ```cpp
-Bob::Bob(ae::AetherApp& aether_app, ae::Client::ptr client_bob)
+Bob::Bob(ae::AetherApp& aether_app, ae::Client::ptr client_bob,
+         TimeSynchronizer& time_synchronizer)
     : aether_{aether_app.aether()},
       client_bob_{std::move(client_bob)},
+      time_synchronizer_{&time_synchronizer},
       new_stream_receive_subscription_{
           client_bob_->client_connection()->new_stream_event().Subscribe(
               *this, ae::MethodPtr<&Bob::OnNewStream>{})} {}
@@ -181,20 +192,26 @@ void Bob::StreamCreated(ae::ByteStream& stream) {
         auto ping_message =
             std::string_view{reinterpret_cast<char const*>(data_buffer.data()),
                              data_buffer.size()};
-        std::cout << "received " << std::quoted(ping_message) << '\n';
+        std::cout << "received " << std::quoted(ping_message) << " within time "
+                  << std::chrono::duration_cast<std::chrono::milliseconds>(
+                         time_synchronizer_->GetPingDuration())
+                         .count()
+                  << " ms\n";
 
+        time_synchronizer_->SetPongSentTime(ae::Now());
         constexpr std::string_view pong_message = "pong";
+        std::cout << "send \"pong\"" << '\n';
         stream.in().Write({std::begin(pong_message), std::end(pong_message)},
                           ae::Now());
       });
 }
 ```
 
-*Bob* forgot to ask *Alice*'s number (uid) and waits maybe she sends him a message.
-He subscribed to `new_stream_event` of his connection to Aethernet object.
-When *Alice* writes a first message to the stream, Aethernet connects it through the server directly to *Bob*.
-He creates the same `P2pSafeStream` with the same properties as *Alice* and so he can parse, decrypt and receive the exact message as *Alice* has sent to him.
-A happy *Bob*, so as not to force the girl wait, immediately sends his "pong" back.
+*Bob* forgot to ask for *Alice*'s number (uid) and hopes she might message him first.
+He subscribes to the `new_stream_event` of his Aethernet connection.
+When *Alice* sends the first message to the stream, Aethernet routes it directly to *Bob* through the server.
+*Bob* then creates a `P2pSafeStream` with the same properties as *Alice*'s, allowing him to parse, decrypt, and receive her exact message.
+Excited, and not wanting to keep her waiting, *Bob* promptly sends his "pong" in response.
 
-## The end
-I've not found a power to stop their chatting. So once you are tired of them, hit the `ctrl+c` or kill the process.
+## The End
+I couldn't find the strength to stop their chatting. So, once you're tired of them, hit `Ctrl+C` or kill the process.

--- a/cpp/desktop-ping-pong/build_and_run.bat
+++ b/cpp/desktop-ping-pong/build_and_run.bat
@@ -1,3 +1,19 @@
+@echo off
+REM Copyright 2025 Aethernet Inc.
+REM
+REM Licensed under the Apache License, Version 2.0 (the "License");
+REM you may not use this file except in compliance with the License.
+REM You may obtain a copy of the License at
+REM
+REM     http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing, software
+REM distributed under the License is distributed on an "AS IS" BASIS,
+REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM See the License for the specific language governing permissions and
+REM limitations under the License.
+@echo on
+
 git submodule update --init --remote aether-client-cpp
 cd aether-client-cpp
 call git_init.bat
@@ -5,6 +21,11 @@ cd ..
 mkdir build-example
 cd build-example
 cmake ..
-cmake --build .
-cd Debug
+cmake --build . --config Release
+cd Release
+
+echo "Get a reference ping to the Aethernet infrastructure"
+ping cloud.aethernet.io
+
+echo "Run example"
 ping-pong-example.exe

--- a/cpp/desktop-ping-pong/build_and_run.sh
+++ b/cpp/desktop-ping-pong/build_and_run.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+# Copyright 2025 Aethernet Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 git submodule update --init --remote aether-client-cpp
 cd aether-client-cpp
 ./git_init.sh
@@ -6,4 +21,9 @@ mkdir build-example
 cd build-example
 cmake ..
 cmake --build .
+
+echo "Get a reference ping to the Aethernet infrastructure"
+ping cloud.aethernet.io -c 5
+
+echo "Run example"
 ./ping-pong-example

--- a/cpp/desktop-ping-pong/ping-pong.cpp
+++ b/cpp/desktop-ping-pong/ping-pong.cpp
@@ -119,18 +119,18 @@ int main() {
 
   auto client_register_action = ClientRegister{*aether_app};
 
-  // Create subscription to Result event
+  // Create a subscription to the Result event
   auto on_registered =
       client_register_action.SubscribeOnResult([&](auto const& action) {
         auto [client_alice, client_bob] = action.get_clients();
         alice = ae::make_unique<Alice>(*aether_app, std::move(client_alice),
                                        client_bob->uid());
         bob = ae::make_unique<Bob>(*aether_app, std::move(client_bob));
-        // Save current aether state
+        // Save the current aether state
         aether_app->domain().SaveRoot(aether_app->aether());
       });
 
-  // Subscription to Error event
+  // Subscription to the Error event
   auto on_register_failed = client_register_action.SubscribeOnError(
       [&](auto const&) { aether_app->Exit(1); });
 

--- a/cpp/desktop-ping-pong/ping-pong.cpp
+++ b/cpp/desktop-ping-pong/ping-pong.cpp
@@ -126,6 +126,8 @@ int main() {
         alice = ae::make_unique<Alice>(*aether_app, std::move(client_alice),
                                        client_bob->uid());
         bob = ae::make_unique<Bob>(*aether_app, std::move(client_bob));
+        // Save current aether state
+        aether_app->domain().SaveRoot(aether_app->aether());
       });
 
   // Subscription to Error event
@@ -165,6 +167,7 @@ void ClientRegister::AliceAndBobRegister() {
   if (aether_->clients().size() == 2) {
     alice_ = aether_->clients()[0];
     bob_ = aether_->clients()[1];
+    AE_TELED_INFO("Used already registered clients");
     state_ = State::kDone;
     return;
   }

--- a/cpp/desktop-ping-pong/ping-pong.cpp
+++ b/cpp/desktop-ping-pong/ping-pong.cpp
@@ -63,11 +63,27 @@ class ClientRegister : public ae::Action<ClientRegister> {
   ae::StateMachine<State> state_;
 };
 
+class TimeSynchronizer {
+ public:
+  TimeSynchronizer() = default;
+
+  void SetPingSentTime(ae::TimePoint ping_sent_time);
+  void SetPongSentTime(ae::TimePoint pong_sent_time);
+
+  ae::Duration GetPingDuration() const;
+  ae::Duration GetPongDuration() const;
+
+ private:
+  ae::TimePoint ping_sent_time_;
+  ae::TimePoint pong_sent_time_;
+};
+
 // Alice sends "ping"s to Bob
 class Alice {
   class IntervalSender : public ae::Action<IntervalSender> {
    public:
-    IntervalSender(ae::ActionContext action_context, ae::ByteStream& stream,
+    IntervalSender(ae::ActionContext action_context,
+                   TimeSynchronizer& time_synchronizer, ae::ByteStream& stream,
                    ae::Duration interval);
 
     ae::TimePoint Update(ae::TimePoint current_time) override;
@@ -76,6 +92,7 @@ class Alice {
     void ResponseReceived(ae::DataBuffer const& data_buffer);
 
     ae::ByteStream& stream_;
+    TimeSynchronizer* time_synchronizer_;
     ae::Duration interval_;
     ae::Subscription response_subscription_;
     ae::TimePoint sent_time_;
@@ -84,7 +101,7 @@ class Alice {
 
  public:
   explicit Alice(ae::AetherApp& aether_app, ae::Client::ptr client_alice,
-                 ae::Uid bobs_uid);
+                 TimeSynchronizer& time_synchronizer, ae::Uid bobs_uid);
 
  private:
   ae::Aether::ptr aether_;
@@ -97,7 +114,8 @@ class Alice {
 // Bob answers "pong" to each "ping"
 class Bob {
  public:
-  explicit Bob(ae::AetherApp& aether_app, ae::Client::ptr client_bob);
+  explicit Bob(ae::AetherApp& aether_app, ae::Client::ptr client_bob,
+               TimeSynchronizer& time_synchronizer);
 
  private:
   void OnNewStream(ae::Uid destination_uid, ae::StreamId stream_id,
@@ -106,6 +124,7 @@ class Bob {
 
   ae::Aether::ptr aether_;
   ae::Client::ptr client_bob_;
+  TimeSynchronizer* time_synchronizer_;
   std::unique_ptr<ae::P2pSafeStream> p2pstream_;
   ae::Subscription new_stream_receive_subscription_;
   ae::Subscription message_receive_subscription_;
@@ -116,6 +135,7 @@ int main() {
 
   std::unique_ptr<Alice> alice;
   std::unique_ptr<Bob> bob;
+  TimeSynchronizer time_synchronizer;
 
   auto client_register_action = ClientRegister{*aether_app};
 
@@ -124,8 +144,8 @@ int main() {
       client_register_action.SubscribeOnResult([&](auto const& action) {
         auto [client_alice, client_bob] = action.get_clients();
         alice = ae::make_unique<Alice>(*aether_app, std::move(client_alice),
-                                       client_bob->uid());
-        bob = ae::make_unique<Bob>(*aether_app, std::move(client_bob));
+                                       time_synchronizer, client_bob->uid());
+        bob = ae::make_unique<Bob>(*aether_app, client_bob, time_synchronizer);
         // Save the current aether state
         aether_app->domain().SaveRoot(aether_app->aether());
       });
@@ -193,8 +213,21 @@ void ClientRegister::AliceAndBobRegister() {
           [&](auto const&) { state_ = State::kError; }));
 }
 
+void TimeSynchronizer::SetPingSentTime(ae::TimePoint ping_sent_time) {
+  ping_sent_time_ = ping_sent_time;
+}
+void TimeSynchronizer::SetPongSentTime(ae::TimePoint pong_sent_time) {
+  pong_sent_time_ = pong_sent_time;
+}
+ae::Duration TimeSynchronizer::GetPingDuration() const {
+  return std::chrono::duration_cast<ae::Duration>(ae::Now() - ping_sent_time_);
+}
+ae::Duration TimeSynchronizer::GetPongDuration() const {
+  return std::chrono::duration_cast<ae::Duration>(ae::Now() - pong_sent_time_);
+}
+
 Alice::Alice(ae::AetherApp& aether_app, ae::Client::ptr client_alice,
-             ae::Uid bobs_uid)
+             TimeSynchronizer& time_synchronizer, ae::Uid bobs_uid)
     : aether_{aether_app.aether()},
       client_alice_{std::move(client_alice)},
       p2pstream_{ae::ActionContext{*aether_->action_processor},
@@ -203,15 +236,18 @@ Alice::Alice(ae::AetherApp& aether_app, ae::Client::ptr client_alice,
                      ae::ActionContext{*aether_->action_processor},
                      client_alice_, bobs_uid, ae::StreamId{0})},
       interval_sender_{ae::ActionContext{*aether_->action_processor},
-                       p2pstream_, std::chrono::milliseconds{5000}},
+                       time_synchronizer, p2pstream_,
+                       std::chrono::milliseconds{5000}},
       interval_sender_subscription_{interval_sender_.SubscribeOnError(
           [&](auto const&) { aether_app.Exit(1); })} {}
 
 Alice::IntervalSender::IntervalSender(ae::ActionContext action_context,
+                                      TimeSynchronizer& time_synchronizer,
                                       ae::ByteStream& stream,
                                       ae::Duration interval)
     : ae::Action<IntervalSender>{action_context},
       stream_{stream},
+      time_synchronizer_{&time_synchronizer},
       interval_{interval},
       response_subscription_{stream.in().out_data_event().Subscribe(
           *this, ae::MethodPtr<&IntervalSender::ResponseReceived>{})} {}
@@ -219,6 +255,9 @@ Alice::IntervalSender::IntervalSender(ae::ActionContext action_context,
 ae::TimePoint Alice::IntervalSender::Update(ae::TimePoint current_time) {
   if (sent_time_ + interval_ <= current_time) {
     constexpr std::string_view ping_message = "ping";
+
+    time_synchronizer_->SetPingSentTime(current_time);
+
     std::cout << "send \"ping\"" << '\n';
     auto send_action = stream_.in().Write(
         {std::begin(ping_message), std::end(ping_message)}, current_time);
@@ -240,15 +279,17 @@ void Alice::IntervalSender::ResponseReceived(
   auto pong_message = std::string_view{
       reinterpret_cast<char const*>(data_buffer.data()), data_buffer.size()};
   std::cout << "received " << std::quoted(pong_message) << " within time "
-            << std::chrono::duration_cast<std::chrono::milliseconds>(ae::Now() -
-                                                                     sent_time_)
+            << std::chrono::duration_cast<std::chrono::milliseconds>(
+                   time_synchronizer_->GetPongDuration())
                    .count()
             << " ms" << '\n';
 }
 
-Bob::Bob(ae::AetherApp& aether_app, ae::Client::ptr client_bob)
+Bob::Bob(ae::AetherApp& aether_app, ae::Client::ptr client_bob,
+         TimeSynchronizer& time_synchronizer)
     : aether_{aether_app.aether()},
       client_bob_{std::move(client_bob)},
+      time_synchronizer_{&time_synchronizer},
       new_stream_receive_subscription_{
           client_bob_->client_connection()->new_stream_event().Subscribe(
               *this, ae::MethodPtr<&Bob::OnNewStream>{})} {}
@@ -269,9 +310,15 @@ void Bob::StreamCreated(ae::ByteStream& stream) {
         auto ping_message =
             std::string_view{reinterpret_cast<char const*>(data_buffer.data()),
                              data_buffer.size()};
-        std::cout << "received " << std::quoted(ping_message) << '\n';
+        std::cout << "received " << std::quoted(ping_message) << " within time "
+                  << std::chrono::duration_cast<std::chrono::milliseconds>(
+                         time_synchronizer_->GetPingDuration())
+                         .count()
+                  << " ms\n";
 
+        time_synchronizer_->SetPongSentTime(ae::Now());
         constexpr std::string_view pong_message = "pong";
+        std::cout << "send \"pong\"" << '\n';
         stream.in().Write({std::begin(pong_message), std::end(pong_message)},
                           ae::Now());
       });

--- a/cpp/platformio-ping-pong/CMakeLists.txt
+++ b/cpp/platformio-ping-pong/CMakeLists.txt
@@ -29,18 +29,20 @@ idf_build_set_property(CM_PLATFORM "ESP32")
 
 add_compile_definitions(CM_ESP32)
 
-if (NOT USER_CONFIG)
-  set(USER_CONFIG "user_config.h")
-endif()
-
 if (NOT FS_INIT)
   set(FS_INIT "file_system_init.h")
 endif()
 
-# by default distillation mode is off, turn it on for this example
+# By default, distillation mode is off; turn it on for this example
 if (NOT DEFINED AE_DISTILLATION)
   set(AE_DISTILLATION On)
 endif()
+
+# add user provided config wich will be included as regular .h file
+# Add a user-provided config file, which will be included as a regular .h file
+set(USER_CONFIG user_config.h)
+# ${USER_CONFIG} must be an absolute path or a path to something listed in include directories
+include_directories(${CMAKE_CURRENT_LIST_DIR}/src)
 
 get_filename_component(configName "${CMAKE_BINARY_DIR}" NAME)
 

--- a/cpp/platformio-ping-pong/src/ping_pong.cpp
+++ b/cpp/platformio-ping-pong/src/ping_pong.cpp
@@ -185,6 +185,8 @@ int AetherPingPongExample() {
         alice = ae::make_unique<Alice>(*aether_app, std::move(client_alice),
                                        client_bob->uid());
         bob = ae::make_unique<Bob>(*aether_app, std::move(client_bob));
+        // Save current aether state
+        aether_app->domain().SaveRoot(aether_app->aether());
       });
 
   // Subscription to Error event
@@ -224,6 +226,7 @@ void ClientRegister::AliceAndBobRegister() {
   if (aether_->clients().size() == 2) {
     alice_ = aether_->clients()[0];
     bob_ = aether_->clients()[1];
+    AE_TELED_INFO("Used already registered clients");
     state_ = State::kDone;
     return;
   }


### PR DESCRIPTION
closes #15 

- Add save aether state after client registration.
- Add object for time sync and printing "ping" and "pong" time. This time should be close to ping time to cloud.aethernet.io
- Add call ping cloud.aethernet.io before run ping-pong in build_and_run scripts
- Add short description about switch from distillation to production mode
- Fix README a little with AI help